### PR TITLE
Add portfolio website project section

### DIFF
--- a/app/api/suggest/route.js
+++ b/app/api/suggest/route.js
@@ -37,7 +37,7 @@ export async function POST(req) {
         // - While testing, keep onboarding@resend.dev and TO = your own Resend account email.
         // - After verifying a domain in Resend, set RESEND_FROM + CONTACT_TO_EMAIL in your env and restart.
         const FROM =
-            process.env.RESEND_FROM || "Network Lab Page Portfolio <onboarding@resend.dev>";
+            process.env.RESEND_FROM || "Portfolio Message <onboarding@resend.dev>";
         const TO = process.env.CONTACT_TO_EMAIL || "damanpreet.nov@gmail.com";
 
         const resend = new Resend(apiKey);
@@ -46,7 +46,7 @@ export async function POST(req) {
             from: FROM,
             to: [TO],
             reply_to: email || undefined,
-            subject: subject || `Message came from NL page from ${name || "Visitor"}`,
+            subject: subject || `Lab Suggestion from ${name || "Visitor"}`,
             html: `
         <div>
           <p><strong>Name:</strong> ${name || "Anonymous"}</p>

--- a/app/components/Hero.jsx
+++ b/app/components/Hero.jsx
@@ -2,9 +2,9 @@ import { useEffect, useState } from "react";
 
 export default function Hero() {
     const LINES = [
-        "Hello, I'm Damanpreet Chauhan",
+        "Hello, I'm Daman Chauhan",
         "I build, support, and secure modern IT infrastructure",
-        "CCNA | Azure | Intune | M365 | Cisco | PowerShell",
+        "Cisco CCNA | Azure | Intune | M365 | GSuite | Comptia A+ | PowerShell",
     ];
 
     const TYPE_SPEED = 40;   // ms per character
@@ -73,7 +73,7 @@ export default function Hero() {
                 {/* Line 3 */}
                 <p>
                     &gt; {typed[2]}
-                    {/* When all done, keep a faint cursor at the end for terminal feel */}
+                    {/* When all done, cursor should faint */}
                     {done ? <Cursor faint /> : stage === 2 && <Cursor />}
                 </p>
             </div>

--- a/app/components/Projects.jsx
+++ b/app/components/Projects.jsx
@@ -10,7 +10,17 @@ export default function Projects() {
             <h2 className="text-4xl font-semibold mb-12 text-center">Projects</h2>
 
             <div className="grid md:grid-cols-2 gap-8">
-                {/* 1) Robot Car (clickable) */}
+                {/* 1) Portfolio Website (clickable) */}
+                <Link href="/projects/portfolio-website" aria-label="View Portfolio Website project">
+                    <Card className={`${baseCard} cursor-pointer hover:bg-neutral-800`}>
+                        <CardContent className="p-6">
+                            <h3 className="text-2xl font-medium mb-2">Portfolio Website</h3>
+                            <p>Next.js, Tailwind CSS, and Framer Motion powering this site.</p>
+                        </CardContent>
+                    </Card>
+                </Link>
+
+                {/* 2) Robot Car (clickable) */}
                 <Link href="/projects/robot-car" aria-label="View Robot Car project">
                     <Card className={`${baseCard} cursor-pointer hover:bg-neutral-800`}>
                         <CardContent className="p-6">
@@ -20,7 +30,7 @@ export default function Projects() {
                     </Card>
                 </Link>
 
-                {/* 2) Networking Lab (clickable) */}
+                {/* 3) Networking Lab (clickable) */}
                 <Link href="/projects/networking-lab" aria-label="View Networking Lab project">
                     <Card className={`${baseCard} cursor-pointer hover:bg-neutral-800`}>
                         <CardContent className="p-6">
@@ -36,7 +46,7 @@ export default function Projects() {
                     </Card>
                 </Link>
 
-                {/* 3) Enterprise Wi‑Fi Design (coming soon, disabled) */}
+                {/* 4) Enterprise Wi‑Fi Design (coming soon, disabled) */}
                 <div aria-disabled className="opacity-70 cursor-not-allowed">
                     <Card className={baseCard}>
                         <CardContent className="p-6">
@@ -53,7 +63,7 @@ export default function Projects() {
                     </Card>
                 </div>
 
-                {/* 4) Intune Automation (coming soon, disabled) */}
+                {/* 5) Intune Automation (coming soon, disabled) */}
                 <div aria-disabled className="opacity-70 cursor-not-allowed">
                     <Card className={baseCard}>
                         <CardContent className="p-6">

--- a/app/components/Projects.jsx
+++ b/app/components/Projects.jsx
@@ -3,7 +3,7 @@ import { Card, CardContent } from "./ui/card";
 
 export default function Projects() {
     const baseCard =
-        "bg-neutral-900 border border-neutral-700 transition-transform duration-200 hover:scale-[1.03]";
+        "bg-neutral-900 border border-neutral-700 transition-transform duration-200 hover:scale-[1.03] h-full";
 
     return (
         <section className="py-20 px-6 md:px-24" id="projects">
@@ -11,7 +11,11 @@ export default function Projects() {
 
             <div className="grid md:grid-cols-2 gap-8">
                 {/* 1) Portfolio Website (clickable) */}
-                <Link href="/projects/portfolio-website" aria-label="View Portfolio Website project">
+                <Link
+                    href="/projects/portfolio-website"
+                    aria-label="View Portfolio Website project"
+                    className="block h-full"
+                >
                     <Card className={`${baseCard} cursor-pointer hover:bg-neutral-800`}>
                         <CardContent className="p-6">
                             <h3 className="text-2xl font-medium mb-2">Portfolio Website</h3>
@@ -21,17 +25,28 @@ export default function Projects() {
                 </Link>
 
                 {/* 2) Robot Car (clickable) */}
-                <Link href="/projects/robot-car" aria-label="View Robot Car project">
+                <Link
+                    href="/projects/robot-car"
+                    aria-label="View Robot Car project"
+                    className="block h-full"
+                >
                     <Card className={`${baseCard} cursor-pointer hover:bg-neutral-800`}>
                         <CardContent className="p-6">
                             <h3 className="text-2xl font-medium mb-2">Robot Car</h3>
-                            <p>Arduino-based car with proximity/camera/avoidance sensors; custom PCB and control logic.</p>
+                            <p>
+                                Arduino-based car with proximity/camera/avoidance sensors; custom PCB and
+                                control logic.
+                            </p>
                         </CardContent>
                     </Card>
                 </Link>
 
                 {/* 3) Networking Lab (clickable) */}
-                <Link href="/projects/networking-lab" aria-label="View Networking Lab project">
+                <Link
+                    href="/projects/networking-lab"
+                    aria-label="View Networking Lab project"
+                    className="block h-full"
+                >
                     <Card className={`${baseCard} cursor-pointer hover:bg-neutral-800`}>
                         <CardContent className="p-6">
                             <h3 className="text-2xl font-medium mb-2 flex items-center gap-2">
@@ -41,7 +56,9 @@ export default function Projects() {
                                 </span>
                             </h3>
 
-                            <p>Home lab with VLANs, OSPF, HSRP, DHCP, and monitoring—configs and diagrams.</p>
+                            <p>
+                                Home lab with VLANs, OSPF, HSRP, DHCP, and monitoring—configs and diagrams.
+                            </p>
                         </CardContent>
                     </Card>
                 </Link>

--- a/app/components/Projects.jsx
+++ b/app/components/Projects.jsx
@@ -18,7 +18,7 @@ export default function Projects() {
                 >
                     <Card className={`${baseCard} cursor-pointer hover:bg-neutral-800`}>
                         <CardContent className="p-6">
-                            <h3 className="text-2xl font-medium mb-2">Portfolio Website</h3>
+                            <h3 className="text-2xl font-medium mb-2">Portfolio Website (This Website)</h3>
                             <p>Next.js, Tailwind CSS, and Framer Motion powering this site.</p>
                         </CardContent>
                     </Card>

--- a/app/projects/portfolio-website/page.jsx
+++ b/app/projects/portfolio-website/page.jsx
@@ -18,9 +18,9 @@ export default function PortfolioWebsiteProject() {
 
             {/* Hero */}
             <section className="px-6 md:px-24 py-10">
-                <h1 className="text-4xl md:text-5xl font-bold">Portfolio Website</h1>
+                <h1 className="text-4xl md:text-5xl font-bold">Daman's Portfolio Website</h1>
                 <p className="mt-3 text-neutral-300 max-w-3xl">
-                    This site is built with Next.js 15, Tailwind CSS, and Framer Motion to showcase my
+                    This website is built with Next.js 15, Tailwind CSS, and Framer Motion to showcase my
                     work with smooth animations, responsive design, and fast navigation using the App
                     Router.
                 </p>
@@ -45,9 +45,9 @@ export default function PortfolioWebsiteProject() {
                         <ul className="list-disc list-inside space-y-2 text-neutral-300">
                             <li>App Router pages for projects, timeline, and certifications</li>
                             <li>Reusable React components styled with Tailwind CSS</li>
-                            <li>Framer Motion transitions for hero, cards, and modals</li>
-                            <li>Contact form using Resend for server-side email delivery</li>
-                            <li>Interactive widgets like a 360° viewer and gallery lightbox</li>
+                            <li>Framer Motion transitions for Introduction typing effect, cards, and models</li>
+                            <li>Contact form using Resend's API for server-side email delivery</li>
+                            <li>Interactive widgets like a 360° viewer</li>
                         </ul>
                     </div>
 
@@ -55,7 +55,7 @@ export default function PortfolioWebsiteProject() {
                         <h3 className="text-xl font-semibold mb-2">Deployment</h3>
                         <p className="text-neutral-300">
                             The site is deployed on Vercel with CI/CD from GitHub. Each push builds
-                            and optimizes the app, serving static assets from the edge for quick
+                            and optimizes the website, serving static assets from the edge for quick
                             global access.
                         </p>
                     </div>
@@ -70,7 +70,8 @@ export default function PortfolioWebsiteProject() {
                             <li>React 19</li>
                             <li>Tailwind CSS 4</li>
                             <li>Framer Motion</li>
-                            <li>Resend (contact form)</li>
+                            <li>Resend API (contact form)</li>
+                            <li>Groq AI API </li>
                             <li>Vercel hosting</li>
                         </ul>
                     </div>
@@ -80,7 +81,7 @@ export default function PortfolioWebsiteProject() {
                         <ul className="space-y-2">
                             <li>
                                 <a
-                                    href="https://github.com/damanpreet-NS/my-portfolio"
+                                    href="https://github.com/axeboyrocks/my-portfolio"
                                     className="text-blue-400 hover:text-blue-300 transition"
                                 >
                                     Source on GitHub
@@ -88,7 +89,7 @@ export default function PortfolioWebsiteProject() {
                             </li>
                             <li>
                                 <a
-                                    href="https://daman-portfolio.vercel.app"
+                                    href="https://damantech.vercel.app"
                                     className="text-blue-400 hover:text-blue-300 transition"
                                 >
                                     Live Site
@@ -99,7 +100,7 @@ export default function PortfolioWebsiteProject() {
 
                     <div className="bg-neutral-900 border border-neutral-800 rounded-2xl p-6">
                         <h3 className="text-xl font-semibold mb-2">Role & Scope</h3>
-                        <p className="text-neutral-300">Solo project: design, development, and deployment.</p>
+                        <p className="text-neutral-300">Solo project: Website design, Working with APIs, development, preview and deployment.</p>
                     </div>
                 </aside>
             </section>

--- a/app/projects/portfolio-website/page.jsx
+++ b/app/projects/portfolio-website/page.jsx
@@ -21,7 +21,8 @@ export default function PortfolioWebsiteProject() {
                 <h1 className="text-4xl md:text-5xl font-bold">Portfolio Website</h1>
                 <p className="mt-3 text-neutral-300 max-w-3xl">
                     This site is built with Next.js 15, Tailwind CSS, and Framer Motion to showcase my
-                    work with smooth animations and responsive design.
+                    work with smooth animations, responsive design, and fast navigation using the App
+                    Router.
                 </p>
             </section>
 
@@ -33,9 +34,29 @@ export default function PortfolioWebsiteProject() {
                         <h2 className="text-2xl font-semibold mb-2">Overview</h2>
                         <p className="text-neutral-300">
                             I designed and developed this portfolio using the Next.js App Router with
-                            React components for each section. Styling is handled with Tailwind CSS
-                            and animations with Framer Motion, allowing fast iterations and a clean
-                            developer experience.
+                            React server and client components for each section. Styling is handled
+                            with Tailwind CSS and animations with Framer Motion, enabling fast
+                            iterations and a clean developer experience.
+                        </p>
+                    </div>
+
+                    <div className="bg-neutral-900 border border-neutral-800 rounded-2xl p-6">
+                        <h3 className="text-xl font-semibold mb-2">Key Features</h3>
+                        <ul className="list-disc list-inside space-y-2 text-neutral-300">
+                            <li>App Router pages for projects, timeline, and certifications</li>
+                            <li>Reusable React components styled with Tailwind CSS</li>
+                            <li>Framer Motion transitions for hero, cards, and modals</li>
+                            <li>Contact form using Resend for server-side email delivery</li>
+                            <li>Interactive widgets like a 360° viewer and gallery lightbox</li>
+                        </ul>
+                    </div>
+
+                    <div className="bg-neutral-900 border border-neutral-800 rounded-2xl p-6">
+                        <h3 className="text-xl font-semibold mb-2">Deployment</h3>
+                        <p className="text-neutral-300">
+                            The site is deployed on Vercel with CI/CD from GitHub. Each push builds
+                            and optimizes the app, serving static assets from the edge for quick
+                            global access.
                         </p>
                     </div>
                 </div>
@@ -49,7 +70,36 @@ export default function PortfolioWebsiteProject() {
                             <li>React 19</li>
                             <li>Tailwind CSS 4</li>
                             <li>Framer Motion</li>
+                            <li>Resend (contact form)</li>
+                            <li>Vercel hosting</li>
                         </ul>
+                    </div>
+
+                    <div className="bg-neutral-900 border border-neutral-800 rounded-2xl p-6">
+                        <h3 className="text-xl font-semibold mb-2">Links</h3>
+                        <ul className="space-y-2">
+                            <li>
+                                <a
+                                    href="https://github.com/damanpreet-NS/my-portfolio"
+                                    className="text-blue-400 hover:text-blue-300 transition"
+                                >
+                                    Source on GitHub
+                                </a>
+                            </li>
+                            <li>
+                                <a
+                                    href="https://daman-portfolio.vercel.app"
+                                    className="text-blue-400 hover:text-blue-300 transition"
+                                >
+                                    Live Site
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+
+                    <div className="bg-neutral-900 border border-neutral-800 rounded-2xl p-6">
+                        <h3 className="text-xl font-semibold mb-2">Role & Scope</h3>
+                        <p className="text-neutral-300">Solo project: design, development, and deployment.</p>
                     </div>
                 </aside>
             </section>

--- a/app/projects/portfolio-website/page.jsx
+++ b/app/projects/portfolio-website/page.jsx
@@ -1,0 +1,65 @@
+import Link from "next/link";
+
+export const metadata = {
+    title: "Portfolio Website | Damanpreet Chauhan",
+    description:
+        "Next.js, Tailwind CSS, and Framer Motion powering this personal website.",
+};
+
+export default function PortfolioWebsiteProject() {
+    return (
+        <main className="bg-black text-white min-h-screen">
+            {/* Top bar / breadcrumb */}
+            <div className="px-6 md:px-24 py-6 border-b border-neutral-800">
+                <Link href="/#projects" className="text-sm text-neutral-400 hover:text-white transition">
+                    ← Back to Projects
+                </Link>
+            </div>
+
+            {/* Hero */}
+            <section className="px-6 md:px-24 py-10">
+                <h1 className="text-4xl md:text-5xl font-bold">Portfolio Website</h1>
+                <p className="mt-3 text-neutral-300 max-w-3xl">
+                    This site is built with Next.js 15, Tailwind CSS, and Framer Motion to showcase my
+                    work with smooth animations and responsive design.
+                </p>
+            </section>
+
+            {/* Content Grid */}
+            <section className="px-6 md:px-24 pb-16 grid md:grid-cols-3 gap-10">
+                {/* Main content */}
+                <div className="md:col-span-2 space-y-6">
+                    <div className="bg-neutral-900 border border-neutral-800 rounded-2xl p-6">
+                        <h2 className="text-2xl font-semibold mb-2">Overview</h2>
+                        <p className="text-neutral-300">
+                            I designed and developed this portfolio using the Next.js App Router with
+                            React components for each section. Styling is handled with Tailwind CSS
+                            and animations with Framer Motion, allowing fast iterations and a clean
+                            developer experience.
+                        </p>
+                    </div>
+                </div>
+
+                {/* Sidebar */}
+                <aside className="space-y-6">
+                    <div className="bg-neutral-900 border border-neutral-800 rounded-2xl p-6">
+                        <h3 className="text-xl font-semibold mb-2">Tech Stack</h3>
+                        <ul className="space-y-1 text-neutral-300">
+                            <li>Next.js 15</li>
+                            <li>React 19</li>
+                            <li>Tailwind CSS 4</li>
+                            <li>Framer Motion</li>
+                        </ul>
+                    </div>
+                </aside>
+            </section>
+
+            {/* Footer back link */}
+            <div className="px-6 md:px-24 pb-12">
+                <Link href="/#projects" className="text-sm text-neutral-400 hover:text-white transition">
+                    ← Back to Projects
+                </Link>
+            </div>
+        </main>
+    );
+}

--- a/app/projects/robot-car/page.jsx
+++ b/app/projects/robot-car/page.jsx
@@ -107,7 +107,7 @@ export default function RobotCarProject() {
                     <div className="bg-neutral-900 border border-neutral-800 rounded-2xl p-6">
                         <h3 className="text-xl font-semibold mb-2">Links</h3>
                         <ul className="space-y-2">
-                            <li><a href="#" className="text-blue-400 hover:text-blue-300 transition">GitHub Repository</a></li>
+                            <li><a href="https://github.com/axeboyrocks/Robot_Car" className="text-blue-400 hover:text-blue-300 transition">GitHub Repository</a></li>
                             <li><a href="#" className="text-blue-400 hover:text-blue-300 transition">Demo Video</a></li>
                         </ul>
                     </div>


### PR DESCRIPTION
## Summary
- showcase portfolio website as a project on the homepage
- add a dedicated project page describing the site's tech stack

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires initial ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a4eab085688329a1102154e1817c86