### PR TITLE
Add Vercel Web Analytics integration

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -1,5 +1,6 @@
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { Analytics } from "@vercel/analytics/next";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -23,6 +24,7 @@ export default function RootLayout({ children }) {
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {children}
+        <Analytics />
       </body>
     </html>
   );

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "next": "15.4.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "@vercel/analytics": "^1.3.0",
     "react-simple-typewriter": "^5.0.1",
     "resend": "^6.0.1"
   },


### PR DESCRIPTION
## Summary
- add @vercel/analytics dependency
- embed Analytics component in layout

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8c77911d48329ad737ff34106180e