### PR TITLE
Send chat logs automatically without IP

### DIFF
--- a/app/components/Daman-ai.js
+++ b/app/components/Daman-ai.js
@@ -85,8 +85,7 @@ export default function DamanAI() {
 
     // ---- Chat log sending utilities ----
     const [sendingLog, setSendingLog] = useState(false);
-    const [sendStatus, setSendStatus] = useState("");
-    const sentRef = useRef(false); // avoid duplicate sends
+    const lastSentCount = useRef(1);
 
     const MAX_BYTES = 50 * 1024; // 50 KB
 
@@ -99,35 +98,23 @@ export default function DamanAI() {
         }
     }
 
-    async function sendChatLog(includeIP, useBeacon = false) {
-        if (sendingLog || sentRef.current) return;
+    async function sendChatLog(useBeacon = false) {
+        if (sendingLog) return;
 
-        const payload = { messages, includeIP: !!includeIP };
+        const payload = { messages, includeIP: false };
         const size = bytesOf(payload.messages);
         if (size > MAX_BYTES) {
-            setSendStatus("Chat log too large to send (limit 50 KB)");
             return;
         }
 
-        // Confirm with user when including IP
-        if (includeIP) {
-            const ok = window.confirm("This will include your public IP address in the emailed log. Do you consent?");
-            if (!ok) return;
-        } else {
-            const ok2 = window.confirm("Send chat log without your IP address?");
-            if (!ok2) return;
-        }
-
         setSendingLog(true);
-        setSendStatus("");
 
         try {
             if (useBeacon && navigator && navigator.sendBeacon) {
                 // sendBeacon expects a Blob/ArrayBufferView
                 const blob = new Blob([JSON.stringify(payload)], { type: "application/json" });
                 navigator.sendBeacon("/api/chat-log", blob);
-                sentRef.current = true;
-                setSendStatus("Sent (via beacon)");
+                lastSentCount.current = messages.length;
             } else {
                 const res = await fetch("/api/chat-log", {
                     method: "POST",
@@ -138,28 +125,34 @@ export default function DamanAI() {
                 if (!res.ok || !json.ok) {
                     throw new Error(json.error || `HTTP ${res.status}`);
                 }
-                sentRef.current = true;
-                setSendStatus("Sent successfully");
+                lastSentCount.current = messages.length;
             }
         } catch (e) {
             console.error("sendChatLog error:", e);
-            setSendStatus("Failed to send: " + (e?.message || "Unknown"));
         } finally {
             setSendingLog(false);
         }
     }
 
-    // Fallback: when user closes tab without choosing, send without IP using sendBeacon (best-effort)
+    // Automatically send logs whenever the conversation updates
+    useEffect(() => {
+        if (messages.length <= 1) return;
+        if (sendingLog) return;
+        if (lastSentCount.current === messages.length) return;
+        lastSentCount.current = messages.length;
+        sendChatLog();
+    }, [messages, sendingLog]);
+
+    // Fallback: when user closes tab, send without IP using sendBeacon (best-effort)
     useEffect(() => {
         const onBeforeUnload = () => {
-            if (sentRef.current) return;
             try {
                 const payload = { messages, includeIP: false };
                 const size = bytesOf(payload.messages);
                 if (size <= MAX_BYTES && navigator && navigator.sendBeacon) {
                     const blob = new Blob([JSON.stringify(payload)], { type: "application/json" });
                     navigator.sendBeacon("/api/chat-log", blob);
-                    sentRef.current = true;
+                    lastSentCount.current = messages.length;
                 }
             } catch (e) {
                 // ignore
@@ -228,31 +221,6 @@ export default function DamanAI() {
                     Reset
                 </button>
             </div>
-
-            {/* Chat log send controls */}
-            <div className="mt-3 flex flex-col sm:flex-row gap-2 justify-center">
-                <button
-                    onClick={() => sendChatLog(true)}
-                    disabled={sendingLog || messages.length <= 1}
-                    className="px-4 py-2 rounded-lg bg-red-600 text-white hover:bg-red-700 disabled:opacity-60"
-                    title="Include your public IP address in the emailed log"
-                >
-                    {sendingLog ? "Sending…" : "Send logs with your public IP address"}
-                </button>
-
-                <button
-                    onClick={() => sendChatLog(false)}
-                    disabled={sendingLog || messages.length <= 1}
-                    className="px-4 py-2 rounded-lg bg-emerald-600 text-white hover:bg-emerald-700 disabled:opacity-60"
-                    title="Send logs without including IP"
-                >
-                    {sendingLog ? "Sending…" : "Send without IP address"}
-                </button>
-            </div>
-
-            {sendStatus && (
-                <p className="text-sm text-center mt-2 text-neutral-500">{sendStatus}</p>
-            )}
 
             <p className="text-xs text-center mt-3 text-zinc-500">
                 Powered by {providerInfo} • Answers use a profile context that Daman control.


### PR DESCRIPTION
## Summary
- remove manual log-sending buttons and status messaging
- automatically send chat logs without IP whenever the conversation updates
- keep a background beacon send on unload for best-effort delivery

## Testing
- npm run lint *(fails: `next` binary unavailable because npm install could not complete in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a72b2ba0883299ff50ecd9832d7d1)